### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/stagietech-studios/8c6ea192-6495-40a7-af38-4eadb258d94e/9f8c47aa-dc23-4ce8-9695-d1ffae7f366b/_apis/work/boardbadge/4e8f934e-463c-4b7e-a2cf-250de8ae859b)](https://dev.azure.com/stagietech-studios/8c6ea192-6495-40a7-af38-4eadb258d94e/_boards/board/t/9f8c47aa-dc23-4ce8-9695-d1ffae7f366b/Microsoft.RequirementCategory)
 # GitHub CLI
 
 `gh` is GitHub on the command line. It brings pull requests, issues, and other GitHub concepts to the terminal next to where you are already working with `git` and your code.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/stagietech-studios/8c6ea192-6495-40a7-af38-4eadb258d94e/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.